### PR TITLE
feat: Implement yymmdd to yyyymmdd Date Conversion Method and Monorepo Testing Structure

### DIFF
--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -1,0 +1,19 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  coveragePathIgnorePatterns: ['/build/', '/node_modules/', '/__tests__/', 'tests'],
+  coverageDirectory: '<rootDir>/coverage/',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+      },
+    ],
+  },
+}
+
+export default config

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from '@jest/types'
+
+import base from './jest.config.base'
+
+const config: Config.InitialOptions = {
+  ...base,
+  roots: ['<rootDir>'],
+  projects: ['<rootDir>/packages/*'],
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check-types:build": "yarn workspaces run tsc --noEmit -p tsconfig.build.json",
     "format": "prettier \"packages/*/src/**/*.ts\" --write",
     "check-format": "prettier -c \"packages/*/src/**/*.ts\"",
-    "test": "yarn workspaces run test",
+    "test": "yarn workspaces run test --passWithNoTests",
     "lint": "eslint \"{packages,apps,libs}/**/*.ts\" --fix",
     "validate": "yarn lint && yarn check-types && yarn check-format"
   },

--- a/packages/client/jest.config.ts
+++ b/packages/client/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types'
+
+import base from '../../jest.config.base'
+
+import packageJson from './package.json'
+
+const config: Config.InitialOptions = {
+  ...base,
+  displayName: packageJson.name,
+}
+
+export default config

--- a/packages/main/jest.config.ts
+++ b/packages/main/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types'
+
+import base from '../../jest.config.base'
+
+import packageJson from './package.json'
+
+const config: Config.InitialOptions = {
+  ...base,
+  displayName: packageJson.name,
+}
+
+export default config

--- a/packages/model/jest.config.ts
+++ b/packages/model/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types'
+
+import base from '../../jest.config.base'
+
+import packageJson from './package.json'
+
+const config: Config.InitialOptions = {
+  ...base,
+  displayName: packageJson.name,
+}
+
+export default config

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,3 +1,4 @@
 export * from './messages'
 export * from './events'
 export * from './types'
+export * from './utils'

--- a/packages/model/src/messages/mrtd/EMrtdDataSubmitMessage.ts
+++ b/packages/model/src/messages/mrtd/EMrtdDataSubmitMessage.ts
@@ -88,6 +88,7 @@ export class EMrtdDataSubmitMessage extends BaseMessage {
       }
     })(mrzString.length)
     const parsedMrz = Mrz.parse(formattedMrz)
+    const rawSex = parsedMrz.fields.sex ?? undefined
     const birthDateFromAdditionalPersonalData = parsed.fields.additionalPersonalData?.fullDateOfBirth
     const dateOfBirth =
       !birthDateFromAdditionalPersonalData || birthDateFromAdditionalPersonalData.toString().length < 6
@@ -101,7 +102,7 @@ export class EMrtdDataSubmitMessage extends BaseMessage {
         documentNumber: parsedMrz.documentNumber ?? undefined,
         issuingState: parsedMrz.fields.issuingState ?? undefined,
         dateOfExpiry: convertShortDate(parsedMrz.fields.expirationDate, true),
-        sex: parsedMrz.fields.sex ?? undefined,
+        sex: rawSex ? rawSex.charAt(0).toUpperCase() : undefined,
         nationality: parsedMrz.fields.nationality ?? undefined,
         lastName: parsedMrz.fields.lastName ?? undefined,
         firstName: parsedMrz.fields.firstName ?? undefined,

--- a/packages/model/src/messages/mrtd/EMrtdDataSubmitMessage.ts
+++ b/packages/model/src/messages/mrtd/EMrtdDataSubmitMessage.ts
@@ -1,6 +1,7 @@
 import { EMrtdData } from '@2060.io/credo-ts-didcomm-mrtd'
 import * as Mrz from 'mrz'
 
+import { convertShortDate } from '../../utils'
 import { BaseMessage, BaseMessageOptions } from '../BaseMessage'
 import { MessageType } from '../MessageType'
 
@@ -99,7 +100,7 @@ export class EMrtdDataSubmitMessage extends BaseMessage {
         documentType: parsedMrz.format,
         documentNumber: parsedMrz.documentNumber ?? undefined,
         issuingState: parsedMrz.fields.issuingState ?? undefined,
-        dateOfExpiry: this.convertMRTDDate(parsedMrz.fields.expirationDate, true),
+        dateOfExpiry: convertShortDate(parsedMrz.fields.expirationDate, true),
         sex: parsedMrz.fields.sex ?? undefined,
         nationality: parsedMrz.fields.nationality ?? undefined,
         lastName: parsedMrz.fields.lastName ?? undefined,
@@ -109,7 +110,7 @@ export class EMrtdDataSubmitMessage extends BaseMessage {
         nameOfHolder:
           parsed.fields.additionalPersonalData?.nameOfHolder ??
           `${parsedMrz.fields.lastName} ${parsedMrz.fields.firstName}`,
-        dateOfBirth: this.convertMRTDDate(dateOfBirth, false),
+        dateOfBirth: convertShortDate(dateOfBirth, false),
         otherNames: parsed.fields.additionalPersonalData?.otherNames,
         personalNumber: parsed.fields.additionalPersonalData?.personalNumber,
         placeOfBirth: parsed.fields.additionalPersonalData?.placeOfBirth,
@@ -122,54 +123,5 @@ export class EMrtdDataSubmitMessage extends BaseMessage {
       },
     }
     return newEmrtdData
-  }
-
-  /**
-   * Converts a Machine Readable Travel Document (MRTD) date in the format `YYMMDD` to a complete
-   * `YYYYMMDD` date format, taking into account the current century.
-   *
-   * **Note:** This method is limited to interpreting dates based on the current year.
-   * It may not handle dates correctly for years beyond the range determined by the
-   * current century (e.g., for dates after 2050 when the current year is in the 21st century).
-   *
-   * @param {string} date - The MRTD date string in the format `YYMMDD`.
-   * @param {boolean} isExpirationDate - A boolean flag indicating whether the date is an expiration date.
-   * @returns {string} - The converted date in the format `YYYYMMDD`, or the original input
-   *                     if the input is not a valid `YYMMDD` date.
-   *
-   * @example
-   * // Current year: 2024
-   * convertMRTDDate("240101"); // Returns "20240101"
-   * convertMRTDDate("991231"); // Returns "19991231"
-   * convertMRTDDate("abcd12"); // Returns "abcd12" (invalid input)
-   */
-  public convertMRTDDate(date: string | null | undefined, isExpirationDate: boolean) {
-    if (!date || !/^\d{6}$/.test(date)) return date ?? undefined
-
-    const currentYear = new Date().getFullYear()
-    const currentCentury = Math.floor(currentYear / 100)
-    const year = parseInt(date.slice(0, 2), 10)
-    const month = date.slice(2, 4)
-    const day = date.slice(4, 6)
-
-    let fullYear: number
-
-    if (isExpirationDate) {
-      if (year <= currentYear % 100) {
-        fullYear = currentCentury * 100 + year
-        if (fullYear < currentYear) {
-          fullYear += 100
-        }
-      } else {
-        fullYear = currentCentury * 100 + year
-      }
-    } else {
-      if (year <= currentYear % 100) {
-        fullYear = currentCentury * 100 + year
-      } else {
-        fullYear = (currentCentury - 1) * 100 + year
-      }
-    }
-    return `${fullYear}${month}${day}`
   }
 }

--- a/packages/model/src/utils/dateUtils.ts
+++ b/packages/model/src/utils/dateUtils.ts
@@ -1,0 +1,48 @@
+/**
+ * Converts a Machine Readable Travel Document (MRTD) date in the format `YYMMDD` to a complete
+ * `YYYYMMDD` date format, taking into account the current century.
+ *
+ * **Note:** This method is limited to interpreting dates based on the current year.
+ * It may not handle dates correctly for years beyond the range determined by the
+ * current century (e.g., for dates after 2050 when the current year is in the 21st century).
+ *
+ * @param {string} date - The MRTD date string in the format `YYMMDD`.
+ * @param {boolean} isExpirationDate - A boolean flag indicating whether the date is an expiration date.
+ * @returns {string} - The converted date in the format `YYYYMMDD`, or the original input
+ *                     if the input is not a valid `YYMMDD` date.
+ *
+ * @example
+ * // Current year: 2024
+ * convertMRTDDate("240101"); // Returns "20240101"
+ * convertMRTDDate("991231"); // Returns "19991231"
+ * convertMRTDDate("abcd12"); // Returns "abcd12" (invalid input)
+ */
+export function convertShortDate(date: string | null | undefined, isExpirationDate: boolean) {
+  if (!date || !/^\d{6}$/.test(date)) return date ?? undefined
+
+  const currentYear = new Date().getFullYear()
+  const currentCentury = Math.floor(currentYear / 100)
+  const year = parseInt(date.slice(0, 2), 10)
+  const month = date.slice(2, 4)
+  const day = date.slice(4, 6)
+
+  let fullYear: number
+
+  if (isExpirationDate) {
+    if (year <= currentYear % 100) {
+      fullYear = currentCentury * 100 + year
+      if (fullYear < currentYear) {
+        fullYear += 100
+      }
+    } else {
+      fullYear = currentCentury * 100 + year
+    }
+  } else {
+    if (year <= currentYear % 100) {
+      fullYear = currentCentury * 100 + year
+    } else {
+      fullYear = (currentCentury - 1) * 100 + year
+    }
+  }
+  return `${fullYear}${month}${day}`
+}

--- a/packages/model/src/utils/index.ts
+++ b/packages/model/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './dateUtils'

--- a/packages/model/tests/DidCommMrtdModel.test.ts
+++ b/packages/model/tests/DidCommMrtdModel.test.ts
@@ -1,0 +1,60 @@
+import {
+  DecodedAdditionalPersonalData,
+  DecodedImage,
+  DecodedSecurtyObjectOfDocument,
+} from '@li0ard/tsemrtd/dist/consts/interfaces'
+
+import { EMrtdDataSubmitMessage, MrtdSubmitState } from '../src/messages'
+
+describe('EMrtdDataSubmitMessage', () => {
+  let securityObjectOfDocument: DecodedSecurtyObjectOfDocument
+  let additionalPersonalData: DecodedAdditionalPersonalData
+  let image: DecodedImage
+  it('should initialize with correct type and state', () => {
+    const rawMock = { someKey: 'someValue' }
+    const parsedMock = {
+      fields: {
+        com: {
+          ldsVersion: '1.7',
+          unicodeVersion: '9.0',
+          tags: Buffer.from('tagsData'),
+        },
+        mrzData: 'P<COLDOE<<JOHN<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<BC123456<2COL9001011M3005103CC12345678<<<<04',
+        images: [
+          {
+            ...image,
+            imageType: 1,
+            imageData: Buffer.from('faceImage1'),
+          },
+        ],
+        additionalPersonalData: {
+          ...additionalPersonalData,
+          nameOfHolder: 'John Doe',
+          fullDateOfBirth: 19900101,
+        },
+        securityObjectOfDocument,
+      },
+      valid: true,
+    }
+
+    const message = new EMrtdDataSubmitMessage({
+      id: '123',
+      threadId: '456',
+      timestamp: new Date(),
+      connectionId: 'conn-1',
+      state: MrtdSubmitState.Submitted,
+      dataGroups: { raw: rawMock, parsed: parsedMock },
+    })
+
+    expect(message.dataGroups?.processed.documentType).toBe('TD3')
+    expect(message.dataGroups?.processed.documentNumber).toBe('BC123456')
+    expect(message.dataGroups?.processed.lastName).toBe('DOE')
+    expect(message.dataGroups?.processed.firstName).toBe('JOHN')
+    expect(message.dataGroups?.processed.dateOfBirth).toBe('19900101')
+    expect(message.dataGroups?.processed.dateOfExpiry).toBe('20300510')
+    expect(message.dataGroups?.processed.sex).toBe('male')
+    expect(message.dataGroups?.processed.nationality).toBe('COL')
+    expect(message.dataGroups?.processed.nameOfHolder).toBe('John Doe')
+    expect(message.dataGroups?.processed.faceImages[0]).toContain('data:image/jp2;base64,')
+  })
+})

--- a/packages/model/tests/DidCommMrtdModel.test.ts
+++ b/packages/model/tests/DidCommMrtdModel.test.ts
@@ -52,7 +52,7 @@ describe('EMrtdDataSubmitMessage', () => {
     expect(message.dataGroups?.processed.firstName).toBe('JOHN')
     expect(message.dataGroups?.processed.dateOfBirth).toBe('19900101')
     expect(message.dataGroups?.processed.dateOfExpiry).toBe('20300510')
-    expect(message.dataGroups?.processed.sex).toBe('male')
+    expect(message.dataGroups?.processed.sex).toBe('M')
     expect(message.dataGroups?.processed.nationality).toBe('COL')
     expect(message.dataGroups?.processed.nameOfHolder).toBe('John Doe')
     expect(message.dataGroups?.processed.faceImages[0]).toContain('data:image/jp2;base64,')

--- a/packages/nestjs-client/jest.config.ts
+++ b/packages/nestjs-client/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types'
+
+import base from '../../jest.config.base'
+
+import packageJson from './package.json'
+
+const config: Config.InitialOptions = {
+  ...base,
+  displayName: packageJson.name,
+}
+
+export default config

--- a/packages/nestjs-client/package.json
+++ b/packages/nestjs-client/package.json
@@ -42,22 +42,5 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "lib": ["ES2021.Promise"],
+    "baseUrl": ".",
+    "paths": {
+      "@2060.io/service-agent-client": ["packages/client/src"],
+      "@2060.io/service-agent-main": ["packages/main/src"],
+      "@2060.io/service-agent-model": ["packages/model/src"],
+      "@2060.io/service-agent-nestjs-client": ["packages/nestjs-client/src"],
+    },
+    "types": ["jest", "node"]
+  },
+  "include": ["tests", "samples", "**/tests", "**/samples"],
+  "exclude": ["node_modules", "build", "**/build/**"]
+}


### PR DESCRIPTION
### Features:  
1. Added a utility method (`convertShortDate`) for handling date conversions, specifically converting `yymmdd` to `yyyymmdd`, adhering to the standard `yyyymmdd` format.  
2. Implemented testing structure for the entire monorepo, with an initial test case created for the EMRTD model. The structure is designed to support future test case additions.