### PR TITLE
fix: Prevent default values for offer time fields when unnecessary

### DIFF
--- a/packages/model/src/messages/calls/CallOfferRequestMessage.ts
+++ b/packages/model/src/messages/calls/CallOfferRequestMessage.ts
@@ -32,11 +32,11 @@ export class CallOfferRequestMessage extends BaseMessage {
   public static readonly type = MessageType.CallOfferRequestMessage
 
   @IsOptional()
-  @Transform(({ value }) => value ? DateParser(value) : undefined)
+  @Transform(({ value }) => (value ? DateParser(value) : undefined))
   public offerExpirationTime?: Date
 
   @IsOptional()
-  @Transform(({ value }) => value ? DateParser(value) : undefined)
+  @Transform(({ value }) => (value ? DateParser(value) : undefined))
   public offerStartTime?: Date
 
   @Expose()

--- a/packages/model/src/messages/calls/CallOfferRequestMessage.ts
+++ b/packages/model/src/messages/calls/CallOfferRequestMessage.ts
@@ -1,5 +1,4 @@
-import { DateParser } from '@credo-ts/core/build/utils/transformers'
-import { Expose, Transform } from 'class-transformer'
+import { Expose } from 'class-transformer'
 import { IsOptional, IsString } from 'class-validator'
 
 import { BaseMessage, BaseMessageOptions } from '../BaseMessage'
@@ -32,11 +31,9 @@ export class CallOfferRequestMessage extends BaseMessage {
   public static readonly type = MessageType.CallOfferRequestMessage
 
   @IsOptional()
-  @Transform(({ value }) => DateParser(value))
   public offerExpirationTime?: Date
 
   @IsOptional()
-  @Transform(({ value }) => DateParser(value))
   public offerStartTime?: Date
 
   @Expose()

--- a/packages/model/src/messages/calls/CallOfferRequestMessage.ts
+++ b/packages/model/src/messages/calls/CallOfferRequestMessage.ts
@@ -1,4 +1,5 @@
-import { Expose } from 'class-transformer'
+import { DateParser } from '@credo-ts/core/build/utils/transformers'
+import { Expose, Transform } from 'class-transformer'
 import { IsOptional, IsString } from 'class-validator'
 
 import { BaseMessage, BaseMessageOptions } from '../BaseMessage'
@@ -31,9 +32,11 @@ export class CallOfferRequestMessage extends BaseMessage {
   public static readonly type = MessageType.CallOfferRequestMessage
 
   @IsOptional()
+  @Transform(({ value }) => value ? DateParser(value) : undefined)
   public offerExpirationTime?: Date
 
   @IsOptional()
+  @Transform(({ value }) => value ? DateParser(value) : undefined)
   public offerStartTime?: Date
 
   @Expose()


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of your changes and why they are needed. Be specific and describe the purpose and impact. -->

## Changes
- Updated the `@Transform` decorator to ensure `offerExpirationTime` and `offerStartTime` are not assigned default values. The transformation now checks the value's existence before parsing it with `DateParser`, avoiding unintended field inclusion.

## Related Issues
<!-- Reference any open issues this PR addresses (e.g., "Fixes #123" or "Fixed problem with ..."). -->

## Testing
<!-- Describe the tests that were run to ensure the changes are working as expected. Include any specific commands or steps needed to reproduce. -->

## Checklist
- [ ] I have commented on my code, especially in areas that are hard to understand.
- [x] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.
