### PR TITLE
fix: collision between anoncreds tails server and short urls

### DIFF
--- a/packages/main/src/didWebServer.ts
+++ b/packages/main/src/didWebServer.ts
@@ -191,8 +191,7 @@ export const addDidWebRoutes = async (
       res.send(404)
     })
 
-    // Allow to create invitation, no other way to ask for invitation yet
-    app.get('/:tailsFileId', async (req, res) => {
+    app.get('/anoncreds/v1/tails/:tailsFileId', async (req, res) => {
       agent.config.logger.debug(`requested file`)
 
       const tailsFileId = req.params.tailsFileId

--- a/packages/main/src/utils/ServiceAgent.ts
+++ b/packages/main/src/utils/ServiceAgent.ts
@@ -84,7 +84,7 @@ export const createServiceAgent = (options: ServiceAgentOptions): ServiceAgent =
         anoncreds: new AnonCredsModule({
           anoncreds,
           tailsFileService: new FullTailsFileService({
-            tailsServerBaseUrl: options.anoncredsServiceBaseUrl,
+            tailsServerBaseUrl: `${options.anoncredsServiceBaseUrl}/anoncreds/v1/tails`,
           }),
           registries: [
             new DidWebAnonCredsRegistry({


### PR DESCRIPTION
## Summary

Add the path /anoncreds/v1/tails to the AnonCreds tails server, in order for it to not collide with other base routes (such as s, for short URLs, invitation and qr).

## Changes
- <!-- Describe the main changes made in this PR. List them point-by-point. -->

## Related Issues
<!-- Reference any open issues this PR addresses (e.g., "Fixes #123" or "Fixed problem with ..."). -->

## Testing
<!-- Describe the tests that were run to ensure the changes are working as expected. Include any specific commands or steps needed to reproduce. -->

## Checklist
- [ ] I have commented on my code, especially in areas that are hard to understand.
- [ ] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.
