### PR TITLE
ci: update library before publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,10 +108,16 @@ jobs:
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}        
         run: |
+          # Publish Model
           yarn workspace @2060.io/service-agent-model version --no-git-tag-version --new-version $RELEASE_VERSION
           yarn workspace @2060.io/service-agent-model publish --non-interactive
+          # Publish Client
+          yarn workspace @2060.io/service-agent-client add @2060.io/service-agent-model@$RELEASE_VERSION
           yarn workspace @2060.io/service-agent-client version --no-git-tag-version --new-version $RELEASE_VERSION
           yarn workspace @2060.io/service-agent-client publish --non-interactive
+          # Publish Nestjs-client
+          yarn workspace @2060.io/service-agent-nestjs-client add @2060.io/service-agent-client@$RELEASE_VERSION
+          yarn workspace @2060.io/service-agent-nestjs-client add @2060.io/service-agent-model@$RELEASE_VERSION
           yarn workspace @2060.io/service-agent-nestjs-client version --no-git-tag-version --new-version $RELEASE_VERSION
           yarn workspace @2060.io/service-agent-nestjs-client publish --non-interactive
           


### PR DESCRIPTION
## Summary
Based on the current dependency publication process, their version must be explicitly specified when dependencies are installed. This can cause issues because the Yarn file may not know which library version to use. Therefore, it is necessary to define the dependencies at the time of publication.

current npm publish 
![image](https://github.com/user-attachments/assets/63e6835d-b126-4c97-8e01-9d9cf68a0884)
> **Note:** @2060.io/service-agent-model and @2060.io/service-agent-client must be defined.

## Changes
- <!-- Describe the main changes made in this PR. List them point-by-point. -->

## Related Issues
<!-- Reference any open issues this PR addresses (e.g., "Fixes #123" or "Fixed problem with ..."). -->

## Testing
<!-- Describe the tests that were run to ensure the changes are working as expected. Include any specific commands or steps needed to reproduce. -->

## Checklist
- [x] I have commented on my code, especially in areas that are hard to understand.
- [ ] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.
