### PR TITLE
fix: invitation to public services using pthid

### DIFF
--- a/packages/main/src/controllers/message/MessageService.ts
+++ b/packages/main/src/controllers/message/MessageService.ts
@@ -285,7 +285,7 @@ export class MessageService {
           // FIXME: This is a workaround due to an issue found in AFJ validator. Replace with class when fixed
           const json = {
             '@type': OutOfBandInvitation.type.messageTypeUri,
-            '@id': did,
+            '@id': utils.uuid(),
             label: label ?? '',
             imageUrl: imageUrl,
             services: [did],
@@ -294,12 +294,8 @@ export class MessageService {
 
           const invitation = OutOfBandInvitation.fromJson(json)
 
-          /*const invitation = new OutOfBandInvitation({ 
-            id: did,
-            label: label ?? '', imageUrl,
-            services: [did],
-            handshakeProtocols: [HandshakeProtocol.DidExchange],
-        })*/
+          // In this special case we use the public did as pthid to indicate recipient to treat as an implicit invitation
+          invitation.setThread({ parentThreadId: did })
 
           await messageSender.sendMessage(
             new OutboundMessageContext(invitation, {
@@ -390,13 +386,18 @@ export class MessageService {
         messageId = requestEMrtdData.messageId
       }
 
-      if (messageId)
-        await agent.genericRecords.save({
-          id: messageId,
-          content: {},
-          tags: { messageId: message.id, connectionId: message.connectionId },
-        })
-      this.logger.debug!(`messageId saved: ${messageId}`)
+      if (messageId) {
+        try {
+          await agent.genericRecords.save({
+            id: messageId,
+            content: {},
+            tags: { messageId: message.id, connectionId: message.connectionId },
+          })
+          this.logger.debug!(`messageId saved: ${messageId}`)
+        } catch (error) {
+          this.logger.warn(`Cannot save message with ${messageId}: ${error.stack}`)
+        }
+      }
       return { id: messageId ?? utils.uuid() } // TODO: persistant mapping between AFJ records and Service Agent flows. Support external message id setting
     } catch (error) {
       this.logger.error(`Error: ${error.stack}`)


### PR DESCRIPTION
BREAKING CHANGE: this generates an invitation that is not compatible with Hologram App <= 2.6.1. 

It will be good to merge it only when Hologram 2.6.2/2.7.0 has been published.

## Summary
<!-- Provide a brief summary of your changes and why they are needed. Be specific and describe the purpose and impact. -->

## Changes
- <!-- Describe the main changes made in this PR. List them point-by-point. -->

## Related Issues
<!-- Reference any open issues this PR addresses (e.g., "Fixes #123" or "Fixed problem with ..."). -->

## Testing
<!-- Describe the tests that were run to ensure the changes are working as expected. Include any specific commands or steps needed to reproduce. -->

## Checklist
- [ ] I have commented on my code, especially in areas that are hard to understand.
- [ ] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.
